### PR TITLE
Fix building of RPM package

### DIFF
--- a/config/rpm/grakn-console.spec
+++ b/config/rpm/grakn-console.spec
@@ -21,6 +21,7 @@ Grakn Core (server) - description
 %install
 mkdir -p %{buildroot}
 tar -xvf {_grakn-console-rpm-tar.tar.gz} -C %{buildroot}
+rm -fv {_grakn-console-rpm-tar.tar.gz}
 
 %files
 


### PR DESCRIPTION
## What is the goal of this PR?

Fix assembly of `grakn-console` RPM package

## What are the changes implemented in this PR?

Remove Grakn Console archive after unpacking (which is now enforced by `rpmbuild`)