### PR TITLE
Use release-validate-deps to ensure that Console depends on released versions of common, console, graql, protocol , and client-java

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - checkout
       - run: |
           bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
-            graknlabs_common graknlabs_console graknlabs_graql graknlabs_protocol
+            graknlabs_common graknlabs_graql graknlabs_protocol graknlabs_client_java
 
   deploy-github:
     machine: true
@@ -196,7 +196,7 @@ workflows:
 
   console-release:
     jobs:
-      - release-approval:
+      - release-validate:
           filters:
             branches:
               only: console-release-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,15 @@ jobs:
           export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
           bazel run @graknlabs_build_tools//ci:release-approval
 
+  release-validate:
+    machine: true
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: |
+          bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
+            graknlabs_common graknlabs_console graknlabs_graql graknlabs_protocol
+
   deploy-github:
     machine: true
     working_directory: ~/console
@@ -187,10 +196,16 @@ workflows:
 
   console-release:
     jobs:
+      - release-approval:
+          filters:
+            branches:
+              only: console-release-branch
       - deploy-github:
           filters:
             branches:
               only: console-release-branch
+          requires:
+            - release-validate
       - deploy-approval:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: git push --delete origin console-release-branch
+      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/console $CIRCLE_BRANCH
 
 workflows:
   console:


### PR DESCRIPTION
## What is the goal of this PR?

We have added a validation step using `//ci:release-validate-deps` in order to ensure that console is releasable only if it depends on released versions of common, console, graql, protocol , and client-java.