### PR TITLE
Make console 1.0.1 releasable by depending on released dependencies

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,14 +29,14 @@ def graknlabs_common():
      git_repository(
          name = "graknlabs_common",
          remote = "https://github.com/graknlabs/common",
-         commit = "1087e5cf567d4bf3ace5ffa6e0e644a201b29741", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+         tag = "0.2.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
      )
 
 def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
          remote = "https://github.com/graknlabs/graql",
-         commit = "9f9ad6beea9fe6364caa19112e9534a70c257735", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+         tag = "1.0.3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
      )
 
 def graknlabs_grakn_core():
@@ -50,7 +50,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "6290833875432a2922f0535231a4493126d7dd0a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        tag = "1.0.2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_client_java():


### PR DESCRIPTION
## What is the goal of this PR?
Make client-java 1.0.1 releasable by depending on released common `0.2.0`, graql `1.0.3`, protocol `1.0.2`. client-java is already set to the correct version which is `1.5.5` and there is no need to update them here.