### PR TITLE
Remove Grakn Core Concept dependency

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -43,7 +43,6 @@ java_library(
         "printer/*.java",
     ]) + [":version"],
     deps = [
-        "@graknlabs_grakn_core//concept", # TODO: To be removed with issue #5288
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
 


### PR DESCRIPTION
Console had a remaining dependency on Grakn Core's implementation of Concept - this has been removed. 

All Grakn core clients should continue to use only Grakn Clients' implementations of Concepts.