### PR TITLE
Add ability to list and delete keyspaces from console

### DIFF
--- a/ConsoleSession.java
+++ b/ConsoleSession.java
@@ -39,9 +39,11 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.commons.lang.StringEscapeUtils.unescapeJava;
@@ -64,6 +66,10 @@ public class ConsoleSession implements AutoCloseable {
     private static final String CLEAR = "clear";
     private static final String EXIT = "exit";
     private static final String CLEAN = "clean";
+    private static final String KEYSPACE = "keyspaces";
+
+    // keyspace sub-commands
+    private static String LIST = "list";
 
     private static final String ANSI_PURPLE = "\u001B[35m";
     private static final String ANSI_RESET = "\u001B[0m";
@@ -170,7 +176,8 @@ public class ConsoleSession implements AutoCloseable {
             } else if (input.equals(EXIT)) {
                 consoleReader.flush();
                 return;
-
+            } else if (input.startsWith(KEYSPACE)) {
+                keyspaceCommand(input.substring(KEYSPACE.length()));
             } else if (!input.isEmpty()) {
                 executeQuery(input);
 
@@ -330,4 +337,13 @@ public class ConsoleSession implements AutoCloseable {
         return System.getProperty("os.name").toLowerCase().contains("win");
     }
 
+    private void keyspaceCommand(String subCommand) throws IOException {
+        String command = subCommand.trim();
+        if (command.equals(LIST)) {
+            List<String> keyspaces = client.keyspaces().retrieve().stream().sorted().collect(Collectors.toList());
+            for (String ksp : keyspaces) {
+                consoleReader.println(ksp);
+            }
+        }
+    }
 }

--- a/ConsoleSession.java
+++ b/ConsoleSession.java
@@ -41,7 +41,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -349,7 +348,8 @@ public class ConsoleSession implements AutoCloseable {
             String keyspaceToDelete = command.substring(DELETE.length() + 1).trim();
             List<String> keyspaces = client.keyspaces().retrieve();
             if (!keyspaces.contains(keyspaceToDelete)) {
-                throw GraknConsoleException.nonexistantKeyspace(keyspaceToDelete);
+                consoleReader.println("Keyspace " + keyspaceToDelete + " does not exist");
+                return;
             }
             client.keyspaces().delete(keyspaceToDelete);
             consoleReader.println("Successfully deleted keyspace: " + keyspaceToDelete);

--- a/ConsoleSession.java
+++ b/ConsoleSession.java
@@ -25,8 +25,8 @@ import graql.lang.Graql;
 import graql.lang.query.GraqlQuery;
 import io.grpc.StatusRuntimeException;
 import jline.console.ConsoleReader;
-import jline.console.history.History;
 import jline.console.history.FileHistory;
+import jline.console.history.History;
 import jline.console.history.MemoryHistory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,9 +39,9 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -66,10 +66,11 @@ public class ConsoleSession implements AutoCloseable {
     private static final String CLEAR = "clear";
     private static final String EXIT = "exit";
     private static final String CLEAN = "clean";
-    private static final String KEYSPACE = "keyspaces";
+    private static final String KEYSPACE = "keyspace";
 
     // keyspace sub-commands
     private static String LIST = "list";
+    private static String DELETE = "delete";
 
     private static final String ANSI_PURPLE = "\u001B[35m";
     private static final String ANSI_RESET = "\u001B[0m";
@@ -344,6 +345,14 @@ public class ConsoleSession implements AutoCloseable {
             for (String ksp : keyspaces) {
                 consoleReader.println(ksp);
             }
+        } else if (command.startsWith(DELETE + ' ')) {
+            String keyspaceToDelete = command.substring(DELETE.length() + 1).trim();
+            List<String> keyspaces = client.keyspaces().retrieve();
+            if (!keyspaces.contains(keyspaceToDelete)) {
+                throw GraknConsoleException.nonexistantKeyspace(keyspaceToDelete);
+            }
+            client.keyspaces().delete(keyspaceToDelete);
+            consoleReader.println("Successfully deleted keyspace: " + keyspaceToDelete);
         }
     }
 }

--- a/exception/GraknConsoleException.java
+++ b/exception/GraknConsoleException.java
@@ -18,6 +18,7 @@
 package grakn.console.exception;
 
 import grakn.client.exception.GraknClientException;
+import grakn.console.GraknConsole;
 
 public class GraknConsoleException extends GraknClientException {
 
@@ -39,6 +40,10 @@ public class GraknConsoleException extends GraknClientException {
 
     public static GraknConsoleException unreachableServer(String serverAddress, RuntimeException e) {
         return GraknConsoleException.create("Unable to create connection to Grakn instance at " + serverAddress, e);
+    }
+
+    public static GraknConsoleException nonexistantKeyspace(String keyspace) {
+        return GraknConsoleException.create("Keyspace " + keyspace + " does not exist");
     }
 
     @Override

--- a/test/BUILD
+++ b/test/BUILD
@@ -32,6 +32,7 @@ java_test(
 
         # External dependencies from @graknlabs
         "@graknlabs_graql//java:graql",
+        "@graknlabs_client_java//:client-java",
 
         # External dependencies
         "//dependencies/maven/artifacts/com/google/auto/value:auto-value",

--- a/test/GraknConsoleIT.java
+++ b/test/GraknConsoleIT.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import grakn.client.GraknClient;
 import grakn.console.GraknConsole;
+import grakn.console.exception.GraknConsoleException;
 import grakn.core.rule.GraknTestServer;
 import graql.lang.Graql;
 import org.apache.commons.io.output.TeeOutputStream;
@@ -434,7 +435,7 @@ public class GraknConsoleIT {
     }
 
     @Test
-    public void when_ListKeyspaces_KeyspacesAreListed() throws Exception {
+    public void when_ListKeyspaces_keyspacesAreListed() throws Exception {
         deleteAllKeyspaces();
 
         // initialise a couple of sessions
@@ -446,12 +447,28 @@ public class GraknConsoleIT {
                 "keyspace list",
                 containsString("a0"),
                 containsString("a1"),
-                containsString("a2")
+                containsString("a2"),
+                containsString("grakn")
         );
     }
 
     @Test
-    public void when_DeleteKeyspace_KeyspaceNotListed() throws Exception {
+    public void when_DeleteNonexistantKeyspace_showUsefulError() throws Exception {
+        deleteAllKeyspaces();
+
+        // initialise a couple of sessions
+        runConsoleSession("", "-k", "a0");
+        runConsoleSession("", "-k", "a1");
+        runConsoleSession("", "-k", "a2");
+
+        assertConsoleSessionMatches(
+                "keyspace delete notakeyspace",
+                containsString("Keyspace notakeyspace does not exist")
+        );
+    }
+
+    @Test
+    public void when_DeleteKeyspace_keyspaceNotListed() throws Exception {
         deleteAllKeyspaces();
 
         // initialise a couple of sessions
@@ -464,7 +481,8 @@ public class GraknConsoleIT {
                 containsString("Successfully deleted keyspace: a01"),
                 "keyspace list",
                 containsString("a1"),
-                containsString("a2")
+                containsString("a2"),
+                containsString("grakn")
         );
     }
 

--- a/test/GraknConsoleIT.java
+++ b/test/GraknConsoleIT.java
@@ -434,16 +434,22 @@ public class GraknConsoleIT {
 
     @Test
     public void when_ListKeyspaces_KeyspacesAreListed() throws Exception {
-        runConsoleSession("", "-k", "keyspace_a");
-        runConsoleSession("", "-k", "keyspace_b");
-        runConsoleSession("", "-k", "keyspace_c");
+        // initialise a couple of sessions
+        // these are going to be ordered alphabetically, so make sure they are lower alphabetically
+        // than keyspaces created in other tests - no ordering guarantee between tests!
+        // and will use the same server without cleaning it every time
+        // TODO add server clean command to console tests
+        server.sessionFactory()
+        runConsoleSession("", "-k", "a0");
+        runConsoleSession("", "-k", "a1");
+        runConsoleSession("", "-k", "a2");
 
         assertConsoleSessionMatches(
                 "keyspaces list",
-                containsString("grakn"),
-                containsString("keyspace_a"),
-                containsString("keyspace_b"),
-                containsString("keyspace_c")
+                containsString("a0"),
+                containsString("a1"),
+                containsString("a2"),
+                anything()
         );
     }
 

--- a/test/GraknConsoleIT.java
+++ b/test/GraknConsoleIT.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import grakn.client.GraknClient;
 import grakn.console.GraknConsole;
-import grakn.console.exception.GraknConsoleException;
 import grakn.core.rule.GraknTestServer;
 import graql.lang.Graql;
 import org.apache.commons.io.output.TeeOutputStream;
@@ -455,6 +454,8 @@ public class GraknConsoleIT {
     @Test
     public void when_DeleteNonexistantKeyspace_showUsefulError() throws Exception {
         deleteAllKeyspaces();
+        // reset keyspace suffix
+        keyspaceSuffix = 0;
 
         // initialise a couple of sessions
         runConsoleSession("", "-k", "a0");
@@ -471,14 +472,17 @@ public class GraknConsoleIT {
     public void when_DeleteKeyspace_keyspaceNotListed() throws Exception {
         deleteAllKeyspaces();
 
+        // reset keyspace suffix
+        keyspaceSuffix = 0;
+
         // initialise a couple of sessions
         runConsoleSession("", "-k", "a0");
         runConsoleSession("", "-k", "a1");
         runConsoleSession("", "-k", "a2");
 
         assertConsoleSessionMatches(
-                "keyspace delete a01", // need to include one because tests increment a counter??
-                containsString("Successfully deleted keyspace: a01"),
+                "keyspace delete a00", // need to include one because tests increment a counter??
+                containsString("Successfully deleted keyspace: a00"),
                 "keyspace list",
                 containsString("a1"),
                 containsString("a2"),

--- a/test/GraknConsoleIT.java
+++ b/test/GraknConsoleIT.java
@@ -439,14 +439,34 @@ public class GraknConsoleIT {
         // than keyspaces created in other tests - no ordering guarantee between tests!
         // and will use the same server without cleaning it every time
         // TODO add server clean command to console tests
-        server.sessionFactory()
         runConsoleSession("", "-k", "a0");
         runConsoleSession("", "-k", "a1");
         runConsoleSession("", "-k", "a2");
 
         assertConsoleSessionMatches(
-                "keyspaces list",
+                "keyspace list",
                 containsString("a0"),
+                containsString("a1"),
+                containsString("a2"),
+                anything()
+        );
+    }
+
+    @Test
+    public void when_DeleteKeyspace_KeyspaceNotListed() throws Exception {
+        // initialise a couple of sessions
+        // these are going to be ordered alphabetically, so make sure they are lower alphabetically
+        // than keyspaces created in other tests - no ordering guarantee between tests!
+        // and will use the same server without cleaning it every time
+        // TODO add server clean command to console tests
+        runConsoleSession("", "-k", "a0");
+        runConsoleSession("", "-k", "a1");
+        runConsoleSession("", "-k", "a2");
+
+        assertConsoleSessionMatches(
+                "keyspace delete a01", // need to include one because tests increment a counter??
+                containsString("Successfully deleted keyspace: a01"),
+                "keyspace list",
                 containsString("a1"),
                 containsString("a2"),
                 anything()

--- a/test/GraknConsoleIT.java
+++ b/test/GraknConsoleIT.java
@@ -432,6 +432,21 @@ public class GraknConsoleIT {
         assertThat(response.err(), not(containsString(".java")));
     }
 
+    @Test
+    public void when_ListKeyspaces_KeyspacesAreListed() throws Exception {
+        runConsoleSession("", "-k", "keyspace_a");
+        runConsoleSession("", "-k", "keyspace_b");
+        runConsoleSession("", "-k", "keyspace_c");
+
+        assertConsoleSessionMatches(
+                "keyspaces list",
+                containsString("grakn"),
+                containsString("keyspace_a"),
+                containsString("keyspace_b"),
+                containsString("keyspace_c")
+        );
+    }
+
     private void assertConsoleSessionMatches(Object... matchers) throws Exception {
         assertConsoleSessionMatchesWithArgs(ImmutableList.of(), matchers);
     }


### PR DESCRIPTION
## What is the goal of this PR?
List, Delete existing keyspaces from console. Previously we had to spin up an interactive python console or something similar to see what keyspaces even exist in a distribution, let alone delete them.
To access the new commands, we would run in any console session:
```
grakn> keyspace list
```
which should print the list of keyspaces on the grakn distribution the console is connected to.

Similarly, we can do:
```
grakn> keyspace delete somekeyspace
Successfully deleted somekeyspace
```

## What are the changes implemented in this PR?
* Add `keyspace list` and `keyspace delete [keyspace]` as a commands in console
* Add test for `keyspace list` and `delete`