### PR TITLE
Migrate load relative path file in and bump deps

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -21,7 +21,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "6cf8cad67fa232d020869fde84e56984bf36d5e7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "abbee2441ccb14c5e9ff12eb7668ecc89d1c6b1d", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_common():
@@ -35,28 +35,28 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/graknlabs/graql",
-        tag = "1.0.6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "9441a23346177e2605b607e6dfab01869cd40530",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "6c07d56b4458f62962e08aaab44b68eb1275e6e3", # do not sync @graknlabs_grakn_core, it will create a cyclic dependency
+        commit = "702a62039dd9f3de3ae9cc1dadf97a1818279e67", # do not sync @graknlabs_grakn_core, it will create a cyclic dependency
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        tag = "1.0.5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "82a29a5cef6b81894181c0d896a3f4f8b5db59fd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        tag = "1.7.1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        commit = "aa95f5211bde21fcf6a007287433fd3592ee9e4b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():

--- a/test/BUILD
+++ b/test/BUILD
@@ -43,7 +43,7 @@ java_test(
     ],
     data = [
         "file-(with-parentheses).gql",
-        "invalid-data.cql",
+        "invalid-data.gql",
         "//test/resources:grakn-properties",
         "//test/resources:cassandra-embedded"],
     size = "large",

--- a/test/GraknConsoleIT.java
+++ b/test/GraknConsoleIT.java
@@ -215,7 +215,7 @@ public class GraknConsoleIT {
     @Test
     public void when_writingRelations_expect_dataIsWritten() throws Exception {
         assertConsoleSessionMatches(
-                "define name sub attribute, datatype string;",
+                "define name sub attribute, value string;",
                 anything(),
                 "define marriage sub relation, relates spouse;",
                 anything(),
@@ -280,7 +280,7 @@ public class GraknConsoleIT {
     @Test
     public void when_writingAggregateGroupQuery_expect_correctGroupingOfAnswers() throws Exception {
         assertConsoleSessionMatches(
-                "define name sub attribute, datatype string;",
+                "define name sub attribute, value string;",
                 anything(),
                 "define person sub entity, has name;",
                 anything(),
@@ -298,7 +298,7 @@ public class GraknConsoleIT {
     public void when_startingConsoleWithOptionNoInfer_expect_queriesDoNotInfer() throws Exception {
         assertConsoleSessionMatchesWithArgs(
                 ImmutableList.of("--no_infer"),
-                "define man sub entity, has name; name sub attribute, datatype string;",
+                "define man sub entity, has name; name sub attribute, value string;",
                 anything(),
                 "define person sub entity;",
                 anything(),
@@ -315,7 +315,7 @@ public class GraknConsoleIT {
     @Test
     public void when_startingConsoleWithoutOptionNoInfer_expect_queriesToInfer() throws Exception {
         assertConsoleSessionMatches(
-                "define man sub entity, has name; name sub attribute, datatype string;",
+                "define man sub entity, has name; name sub attribute, value string;",
                 anything(),
                 "define person sub entity;",
                 anything(),

--- a/test/GraknConsoleIT.java
+++ b/test/GraknConsoleIT.java
@@ -57,6 +57,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -177,6 +178,28 @@ public class GraknConsoleIT {
                 containsString("1")
         );
     }
+
+    @Test
+    public void when_givenRelativeFilePath_dataIsLoaded() throws Exception {
+        String fileName = "test.gql";
+        Files.write(Paths.get(fileName), "define person sub entity; name sub attribute, value string;\n".getBytes());
+        Response response = runConsoleSession("", "-k", "relative_path_load", "-f", fileName);
+        assertEquals("", response.err());
+        response = runConsoleSession("match $x sub thing; get;\n", "-k", "relative_path_load");
+        // Check for a few expected usage messages
+        assertThat(
+                response.out(),
+                allOf(
+                        containsString("thing"),
+                        containsString("entity"),
+                        containsString("person"),
+                        containsString("relation"),
+                        containsString("attribute"),
+                        containsString("name")
+                )
+        );
+    }
+
 
     @Test
     public void when_writingMatchQueries_expect_resultsReturned() {

--- a/test/GraknConsoleIT.java
+++ b/test/GraknConsoleIT.java
@@ -57,7 +57,6 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -163,7 +162,7 @@ public class GraknConsoleIT {
 
     @Test
     public void when_loadingInvalidDataFromFile_expectError() {
-        Response response = runConsoleSession("", "-f", "test/invalid-data.cql");
+        Response response = runConsoleSession("", "-f", "test/invalid-data.gql");
 
         assertThat(response.err(), allOf(containsString("Failed to load file:"), containsString("A structural validation error has occurred.")));
         assertThat(response.out(), not(containsString("Successful commit:")));
@@ -262,7 +261,7 @@ public class GraknConsoleIT {
                 anything(),
                 "insert $x isa person;",
                 anything(),
-                "match $x isa person; delete $x;",
+                "match $x isa person; delete $x isa person;",
                 containsString("success"),
                 "rollback"
         );

--- a/test/invalid-data.gql
+++ b/test/invalid-data.gql
@@ -1,7 +1,7 @@
 define
 
 example-id sub attribute,
-    datatype long;
+    value long;
 
 person sub entity,
     has example-id,


### PR DESCRIPTION
## What is the goal of this PR?
https://github.com/graknlabs/grakn/issues/5043 as a part of refactoring test packages in core, we move one `end-to-end test` into console as it should not have been tested in core.

Bump dependencies of core, protocol, client-java, build-tools. Significant change includes using `value` instead of `datatype`.

## What are the changes implemented in this PR?
* Migrate one test from grakn core
* Switch tests to use `value` instead of `datatype`