### PR TITLE
Update to new client java future syntax

### DIFF
--- a/ConsoleSession.java
+++ b/ConsoleSession.java
@@ -208,7 +208,7 @@ public class ConsoleSession implements AutoCloseable {
             // Get the stream of answers for each query (query.stream())
             // Get the  stream of printed answers (printer.toStream(..))
             // Combine the stream of printed answers into one stream (queries.flatMap(..))
-            Stream<String> answers = queries.flatMap(query -> printer.toStream(tx, tx.stream(query, infer)));
+            Stream<String> answers = queries.flatMap(query -> printer.toStream(tx, tx.stream(query, infer).get()));
 
             // For each printed answer, print them on one line
             answers.forEach(answer -> {

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -42,7 +42,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "702a62039dd9f3de3ae9cc1dadf97a1818279e67", # do not sync @graknlabs_grakn_core, it will create a cyclic dependency
+        commit = "b65213143c5181dc5ad7f29cedc82564f1356822", # do not sync @graknlabs_grakn_core, it will create a cyclic dependency
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -55,8 +55,8 @@ def graknlabs_protocol():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
-        commit = "aa95f5211bde21fcf6a007287433fd3592ee9e4b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/adammitchelldev/client-java",
+        commit = "a8454645bb0df2623a2a4c3698094beac3ca8149", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -42,7 +42,7 @@ def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "b65213143c5181dc5ad7f29cedc82564f1356822", # do not sync @graknlabs_grakn_core, it will create a cyclic dependency
+        commit = "f1b7fa5dc751f6f491cffa9886ed09932dc932eb", # do not sync @graknlabs_grakn_core, it will create a cyclic dependency
     )
 
 def graknlabs_protocol():
@@ -55,8 +55,8 @@ def graknlabs_protocol():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/adammitchelldev/client-java",
-        commit = "a8454645bb0df2623a2a4c3698094beac3ca8149", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/graknlabs/client-java",
+        commit = "e1f2d0aa6d2ad69aecb33e31bdd2c39362f14310", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():

--- a/test/BUILD
+++ b/test/BUILD
@@ -28,7 +28,7 @@ java_test(
         "//:console",
 
         # Internal dependencies # TODO: should be removed with #1
-        "@graknlabs_grakn_core//test-integration/rule:grakn-test-server",
+        "@graknlabs_grakn_core//test/rule:grakn-test-server",
 
         # External dependencies from @graknlabs
         "@graknlabs_graql//java:graql",
@@ -49,7 +49,7 @@ java_test(
     size = "large",
     classpath_resources = [
         # TODO: should be removed with #1
-        "@graknlabs_grakn_core//test-integration/resources:logback-test",
+        "@graknlabs_grakn_core//test/resources:logback-test",
     ]
 )
 

--- a/test/GraknConsoleIT.java
+++ b/test/GraknConsoleIT.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import grakn.client.GraknClient;
 import grakn.console.GraknConsole;
-import grakn.core.rule.GraknTestServer;
+import grakn.core.test.rule.GraknTestServer;
 import graql.lang.Graql;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.hamcrest.Matcher;


### PR DESCRIPTION
## What is the goal of this PR?

For 1.8, `client-java` syntax has changed to return a `Future` from query methods. This requires us to update on our end.

## What are the changes implemented in this PR?

- Updated to new `client-java` syntax