### PR TITLE
Update to 1.8 dependencies

### DIFF
--- a/ConsoleSession.java
+++ b/ConsoleSession.java
@@ -208,7 +208,7 @@ public class ConsoleSession implements AutoCloseable {
             // Get the stream of answers for each query (query.stream())
             // Get the  stream of printed answers (printer.toStream(..))
             // Combine the stream of printed answers into one stream (queries.flatMap(..))
-            Stream<String> answers = queries.flatMap(query -> printer.toStream(tx, tx.stream(query, infer)));
+            Stream<String> answers = queries.flatMap(query -> printer.toStream(tx, tx.stream(query, infer).get()));
 
             // For each printed answer, print them on one line
             answers.forEach(answer -> {

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -35,28 +35,28 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/graknlabs/graql",
-        commit = "9441a23346177e2605b607e6dfab01869cd40530",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "4e37a87cb562e47f04c270c6147eac2567d4a223",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_grakn_core():
     git_repository(
         name = "graknlabs_grakn_core",
         remote = "https://github.com/graknlabs/grakn",
-        commit = "702a62039dd9f3de3ae9cc1dadf97a1818279e67", # do not sync @graknlabs_grakn_core, it will create a cyclic dependency
+        commit = "f1b7fa5dc751f6f491cffa9886ed09932dc932eb", # do not sync @graknlabs_grakn_core, it will create a cyclic dependency
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "82a29a5cef6b81894181c0d896a3f4f8b5db59fd", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "61b04688abf4d7537bd9a783f0161cf4e4c24559", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
-        commit = "aa95f5211bde21fcf6a007287433fd3592ee9e4b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/flyingsilverfin/client-java",
+        commit = "1959abd62eb47bb9a1089985a35b1cc147b6c907", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -55,8 +55,8 @@ def graknlabs_protocol():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/flyingsilverfin/client-java",
-        commit = "1959abd62eb47bb9a1089985a35b1cc147b6c907", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/graknlabs/client-java",
+        commit = "e753c7c1997a1e041441a1f93f9a1ab0bd467848", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )
 
 def graknlabs_grabl_tracing():

--- a/test/BUILD
+++ b/test/BUILD
@@ -28,7 +28,7 @@ java_test(
         "//:console",
 
         # Internal dependencies # TODO: should be removed with #1
-        "@graknlabs_grakn_core//test-integration/rule:grakn-test-server",
+        "@graknlabs_grakn_core//test/rule:grakn-test-server",
 
         # External dependencies from @graknlabs
         "@graknlabs_graql//java:graql",
@@ -49,7 +49,7 @@ java_test(
     size = "large",
     classpath_resources = [
         # TODO: should be removed with #1
-        "@graknlabs_grakn_core//test-integration/resources:logback-test",
+        "@graknlabs_grakn_core//test/resources:logback-test",
     ]
 )
 

--- a/test/GraknConsoleIT.java
+++ b/test/GraknConsoleIT.java
@@ -262,7 +262,7 @@ public class GraknConsoleIT {
                 "insert $x isa person;",
                 anything(),
                 "match $x isa person; delete $x isa person;",
-                containsString("success"),
+                containsString("Deleted facts from"),
                 "rollback"
         );
     }

--- a/test/GraknConsoleIT.java
+++ b/test/GraknConsoleIT.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import grakn.client.GraknClient;
 import grakn.console.GraknConsole;
-import grakn.core.rule.GraknTestServer;
+import grakn.core.test.rule.GraknTestServer;
 import graql.lang.Graql;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.hamcrest.Matcher;


### PR DESCRIPTION
## What is the goal of this PR?
We upgrade console to use the latest grakn core and client-java dependencies, resolving their own build issues induced by circular dependencies.

## What are the changes implemented in this PR?
* Bump client-java to one of the latest version
* Bump grakn-core to the latest master
* Bump protocol to newest protocol
* Bump graql to newest commit