### PR TITLE
Remove extra logback inclusion

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -71,8 +71,6 @@ java_binary(
     name = "console-binary",
     main_class = "grakn.console.GraknConsole",
     runtime_deps = [":console"],
-    resources = ["//config/logback:logback.xml"],
-    resource_strip_prefix = "config/logback",
     visibility = ["//:__pkg__"],
 )
 


### PR DESCRIPTION
## What is the goal of this PR?
Starting console from April 2020 onwards resulted in verbose startup logging. This was due to an extra logback file being included in the JAR, which we remove again.

## What are the changes implemented in this PR?
* Remove logback from the JAR, resulting in no duplicate logback and therefore no error messages on console bootup.