### PR TITLE
Add console-deps deployment to repo as archive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,14 @@ workflows:
           filters:
             branches:
               only: master
+      - deploy-distribution-snapshot:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - build-analysis
+            - test-integration
       - deploy-apt-snapshot:
           filters:
             branches:
@@ -224,6 +232,7 @@ workflows:
             branches:
               only: master
           requires:
+            - deploy-distribution-snapshot
             - deploy-apt-snapshot
             - deploy-rpm-snapshot
 
@@ -246,6 +255,12 @@ workflows:
           filters:
             branches:
               only: console-release-branch
+      - deploy-distribution:
+          filters:
+            branches:
+              only: console-release-branch
+          requires:
+            - deploy-approval
       - deploy-apt:
           filters:
             branches:
@@ -263,6 +278,7 @@ workflows:
             branches:
               only: console-release-branch
           requires:
+            - deploy-distribution
             - deploy-apt
             - deploy-rpm
       - release-cleanup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,17 @@ jobs:
             bazel run @graknlabs_build_tools//sonarcloud:code-analysis -- \
             --project-key graknlabs_console --branch=$CIRCLE_BRANCH --commit-id=$CIRCLE_SHA1
 
+  deploy-distribution-snapshot:
+    machine: true
+    working_directory: ~/console
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: |
+          export DEPLOY_DISTRIBUTION_USERNAME=$REPO_GRAKN_USERNAME
+          export DEPLOY_DISTRIBUTION_PASSWORD=$REPO_GRAKN_PASSWORD
+          bazel run --define version=$(git rev-parse HEAD) //:deploy-console-deps -- snapshot
+
   deploy-apt-snapshot:
     machine: true
     working_directory: ~/console
@@ -110,6 +121,17 @@ jobs:
       - run: |
           bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
             graknlabs_common graknlabs_graql graknlabs_client_java
+
+  deploy-distribution:
+    machine: true
+    working_directory: ~/console
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: |
+          export DEPLOY_DISTRIBUTION_USERNAME=$REPO_GRAKN_USERNAME
+          export DEPLOY_DISTRIBUTION_PASSWORD=$REPO_GRAKN_PASSWORD
+          bazel run --define version=$(cat VERSION) //:deploy-console-deps -- release
 
   deploy-github:
     machine: true

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ grakn-test/test-biomed/data/*
 
 # Python cache #
 __pycache__
+
+
+# bazel-local #
+.local_deps*

--- a/BUILD
+++ b/BUILD
@@ -21,6 +21,7 @@ load("@graknlabs_bazel_distribution//common:rules.bzl", "assemble_targz", "java_
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@graknlabs_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
 load("@graknlabs_bazel_distribution//rpm:rules.bzl", "assemble_rpm", "deploy_rpm")
+load("@graknlabs_bazel_distribution//distribution:rules.bzl", "deploy_distribution")
 load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
 
 genrule(
@@ -63,7 +64,7 @@ java_library(
 checkstyle_test(
     name = "checkstyle",
     targets = [
-        ":console"
+        ":console",
     ],
 )
 
@@ -78,7 +79,15 @@ java_deps(
     name = "console-deps",
     target = ":console-binary",
     java_deps_root = "console/services/lib/",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+)
+
+deploy_distribution(
+    name = "deploy-console-deps",
+    target = ":console-deps",
+    artifact_group = "graknlabs_console",
+    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
+    visibility = ["//visibility:public"],
 )
 
 assemble_targz(

--- a/deployment.properties
+++ b/deployment.properties
@@ -17,3 +17,5 @@
 
 repo.github.organisation=graknlabs
 repo.github.repository=console
+
+repo.distribution.group=graknlabs_console

--- a/deployment.properties
+++ b/deployment.properties
@@ -17,5 +17,3 @@
 
 repo.github.organisation=graknlabs
 repo.github.repository=console
-
-repo.distribution.group=graknlabs_console


### PR DESCRIPTION
## What is the goal of this PR?

Grakn core depends on console in order to create an "all" release package, however, it currently builds console from source (via bazel) which means we have two "releases" of console, one in this repo and one in the `grakn` repo, and they can have different sets of dependencies. This could cause any number of problems, not least being that tests run in this repo do not necessarily reflect the correctness of console in `grakn`. It also causes problems for us locally when using bazel to develop locally, because external workspaces imported in our own repo can leak into console unintended.

In order to fix this "artifact drift" we need to move to a "single true artifact" pattern. Currently, this artifact will only be `console-deps`, which does not include configuration (only `logback.xml` right now). At some point, we should move to the full `console` release being the distributed artifact and combined into the `grakn` "all" release.

## What are the changes implemented in this PR?

- Added `deploy-console-deps` distribution rule for `grakn` to depend on.
- Added CI/CD to deploy this.
