### PR TITLE
Remove sync-dependencies from workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,7 +283,7 @@ workflows:
               only: console-release-branch
           requires:
             - deploy-approval
-      - sync-dependencies-release:
+      - release-cleanup:
           filters:
             branches:
               only: console-release-branch
@@ -291,9 +291,3 @@ workflows:
             - deploy-artifact
             - deploy-apt
             - deploy-rpm
-      - release-cleanup:
-          filters:
-            branches:
-              only: console-release-branch
-          requires:
-            - sync-dependencies-release


### PR DESCRIPTION
## What is the goal of this PR?

We have removed sync-dependencies completely. It will be replaced by Grabl 2.0's sync pipeline soon.