### PR TITLE
Make ctrl-c possible to break out of REPL loop

### DIFF
--- a/ReplCommand.java
+++ b/ReplCommand.java
@@ -19,9 +19,7 @@ package grakn.console;
 
 import grakn.client.Grakn;
 import grakn.common.collection.Pair;
-import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
-import org.jline.reader.UserInterruptException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -115,10 +113,10 @@ public abstract class ReplCommand {
         return Utils.buildHelpMenu(menu);
     }
 
-    public static ReplCommand getCommand(LineReader reader, Printer printer, String prompt) {
+    public static ReplCommand getCommand(LineReader reader, Printer printer, String prompt) throws InterruptedException {
         ReplCommand command = null;
         while (command == null) {
-            String[] tokens = getTokens(reader, printer, prompt);
+            String[] tokens = Utils.getTokens(reader, prompt);
             if (tokens.length == 1 && tokens[0].equals(Exit.token)) {
                 command = new Exit();
             } else if (tokens.length == 1 && tokens[0].equals(Help.token)) {
@@ -144,19 +142,5 @@ public abstract class ReplCommand {
             }
         }
         return command;
-    }
-
-    private static String[] getTokens(LineReader reader, Printer printer, String prompt) {
-        String[] words = null;
-        while (words == null) {
-            try {
-                String line = reader.readLine(prompt);
-                words = Utils.splitLineByWhitespace(line);
-                if (words.length == 0) words = null;
-            } catch (UserInterruptException | EndOfFileException e) {
-                printer.info("Use command '" + Exit.token + "' to exit the console");
-            }
-        }
-        return words;
     }
 }

--- a/TransactionReplCommand.java
+++ b/TransactionReplCommand.java
@@ -105,9 +105,9 @@ public abstract class TransactionReplCommand {
         return Utils.buildHelpMenu(menu);
     }
 
-    public static TransactionReplCommand getCommand(LineReader reader, Printer printer, String prompt) {
+    public static TransactionReplCommand getCommand(LineReader reader, String prompt) throws InterruptedException {
         TransactionReplCommand command;
-        String[] tokens = getTokens(reader, printer, prompt);
+        String[] tokens = Utils.getTokens(reader, prompt);
         if (tokens.length == 1 && tokens[0].equals(Exit.token)) {
             command = new Exit();
         } else if (tokens.length == 1 && tokens[0].equals(Help.token)) {
@@ -149,19 +149,5 @@ public abstract class TransactionReplCommand {
             }
         }
         return String.join("\n", queryLines);
-    }
-
-    private static String[] getTokens(LineReader reader, Printer printer, String prompt) {
-        String[] words = null;
-        while (words == null) {
-            try {
-                String line = reader.readLine(prompt);
-                words = Utils.splitLineByWhitespace(line);
-                if (words.length == 0) words = null;
-            } catch (UserInterruptException | EndOfFileException e) {
-                printer.info("Use command '" + Exit.token + "' to exit the console");
-            }
-        }
-        return words;
     }
 }

--- a/Utils.java
+++ b/Utils.java
@@ -18,15 +18,14 @@
 package grakn.console;
 
 import grakn.common.collection.Pair;
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.LineReader;
+import org.jline.reader.UserInterruptException;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class Utils {
-    public static String[] splitLineByWhitespace(String line) {
-        return Arrays.stream(line.split("\\s+")).map(String::trim).filter(x -> !x.isEmpty()).toArray(String[]::new);
-    }
-
     public static String buildHelpMenu(List<Pair<String, String>> menu) {
         if (menu.isEmpty()) return "\n";
         int maxHelpCommandLength = menu.stream().map(x -> x.first().length()).max(Integer::compare).get();
@@ -41,5 +40,27 @@ public class Utils {
             sb.append("\n");
         }
         return sb.toString();
+    }
+
+    public static String[] getTokens(LineReader reader, String prompt) throws InterruptedException {
+        String[] words = null;
+        while (words == null) {
+            try {
+                String line = reader.readLine(prompt);
+                words = Utils.splitLineByWhitespace(line);
+                if (words.length == 0) words = null;
+            } catch (UserInterruptException e) {
+                if (reader.getBuffer().toString().isEmpty()) {
+                    throw new InterruptedException();
+                }
+            } catch (EndOfFileException e) {
+                throw new InterruptedException();
+            }
+        }
+        return words;
+    }
+
+    private static String[] splitLineByWhitespace(String line) {
+        return Arrays.stream(line.split("\\s+")).map(String::trim).filter(x -> !x.isEmpty()).toArray(String[]::new);
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Make ctrl-c possible to escape from the REPL loop.

- ctrl-c on the first level of REPL will exit the console
- ctrl-c on the second level of REPL will go back to the first level
- In both cases, when there are already input, it will just cancel the input without cancel the REPL loop.

This solution is **NOT** perfect, since now with a long running query, ctrl-c will kill the entire console. To properly handle that, we need to register signal handler and there will be more work related to it.

## What are the changes implemented in this PR?

- Make `getCommand` call throws `InterruptedException` when the user interrupts with `ctrl-c`.
