### PR TITLE
Make stream result iteration cancellable

### DIFF
--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -202,7 +202,7 @@ public class GraknConsole {
             boolean[] isCancelled = new boolean[1];
             terminal.handle(Terminal.Signal.INT, s -> isCancelled[0] = true);
             Iterator<ConceptMap> iterator = conceptMaps.iterator();
-            while (!isCancelled[0]) {
+            while (!isCancelled[0] && iterator.hasNext()) {
                 printer.conceptMap(iterator.next(), tx);
             }
         } finally {


### PR DESCRIPTION
## What is the goal of this PR?

Make **only** the result streaming query cancellable, all other operations will ignore interrupts.

## What are the changes implemented in this PR?

Install a signal handler to set `isCancelled` to true on ctrl-c interrupt so that we will break out iterating over the concept map stream.
