### PR TITLE
Allow commit dependencies on common and client-java

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -2,8 +2,8 @@ config:
   version-candidate: VERSION
   dependencies:
     dependencies: [build]
-    common: [release]
-    client-java: [release]
+    common: [build, release]
+    client-java: [build, release]
 
 build:
   quality:


### PR DESCRIPTION
## What is the goal of this PR?

Currently, we depend on commits of `common` and `client-java` which makes `dependency-analysis` fail.

## What are the changes implemented in this PR?

Allow us to depend on commits of `common` and `client-java`