### PR TITLE
Build remotely on Ubuntu 20.04

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,29 +4,12 @@ test --incompatible_strict_action_env
 
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev
-build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=cloud.buildbuddy.io
 build:rbe --remote_executor=cloud.buildbuddy.io
 build:rbe --bes_backend=cloud.buildbuddy.io
 build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
 build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
 build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
-build:rbe --host_platform=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --extra_execution_platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/config:cc-toolchain
-build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/cc:toolchain
+build:rbe --host_platform=@graknlabs_dependencies//image/buildbuddy:ubuntu-2004
 build:rbe --jobs=50
 build:rbe --remote_timeout=3600
-build:rbe --bes_timeout=600s
-build:rbe --spawn_strategy=remote
-build:rbe --strategy=Javac=remote
-build:rbe --strategy=Closure=remote
-build:rbe --genrule_strategy=remote
-build:rbe --define=EXECUTOR=remote
-build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:rbe --experimental_strict_action_env=true

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -30,7 +30,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-        bazel build //...
+        bazel build --config=rbe //...
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
     deploy-artifact-snapshot:

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "ed2c074bea897dada26e4f112c1d08f739e90012",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "172e16ed56a83ff4c9815b1ebcdeea7ddb92860f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

In order to speed up our builds, we should do them remotely on BuildBuddy

## What are the changes implemented in this PR?

Tweak `.bazelrc` settings to build on BuildBuddy with our own Ubuntu 20.04 image