### PR TITLE
Adapt to new grabl

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -2,8 +2,8 @@ config:
   version-candidate: VERSION
   dependencies:
     dependencies: [build]
-    common: [build, release]
-    client-java: [build, release]
+    common: [build]
+    client-java: [build]
 
 build:
   quality:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -2,8 +2,8 @@ config:
   version-candidate: VERSION
   dependencies:
     dependencies: [build]
-    common: [build]
-    client-java: [build]
+    common: [build] # TODO: add 'release' once dependency-analysis works with tags
+    client-java: [build] # TODO: add 'release' once dependency-analysis works with tags
 
 build:
   quality:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -11,19 +11,19 @@ build:
       owner: graknlabs
       branch: master
     build-analysis:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       type: foreground
       script: |
         SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
            bazel run @graknlabs_dependencies//tool/sonarcloud:code-analysis -- \
            --project-key graknlabs_console --branch=$GRABL_BRANCH --commit-id=$GRABL_COMMIT
     dependency-analysis:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         bazel run @graknlabs_dependencies//grabl/analysis:dependency-analysis
   correctness:
     build:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       type: foreground
       script: |
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
@@ -37,7 +37,7 @@ build:
       filter:
         owner: graknlabs
         branch: master
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       type: foreground
       dependencies: [build]
       script: |
@@ -51,7 +51,7 @@ build:
       filter:
         owner: graknlabs
         branch: master
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       type: foreground
       dependencies: [build]
       script: |
@@ -65,7 +65,7 @@ build:
       filter:
         owner: graknlabs
         branch: master
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       type: foreground
       dependencies: [build]
       script: |
@@ -82,7 +82,7 @@ release:
     branch: master
   validation:
     validate-dependencies:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       type: foreground
       script: |
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
@@ -91,7 +91,7 @@ release:
         bazel test //:release-validate-deps  --test_output=streamed
   deployment:
     deploy-github:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       type: foreground
       script: |
         export ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
@@ -103,7 +103,7 @@ release:
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
         bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
     deploy-apt-release:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       dependencies: [deploy-github]
       type: foreground
       script: |
@@ -115,7 +115,7 @@ release:
         export DEPLOY_APT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run --define version=$(cat VERSION) //:deploy-apt -- release
     deploy-rpm-release:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       dependencies: [deploy-github]
       type: foreground
       script: |
@@ -126,7 +126,7 @@ release:
         export DEPLOY_RPM_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //:deploy-rpm -- snapshot
     deploy-artifact-release:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       dependencies: [deploy-github]
       type: foreground
       script: |


### PR DESCRIPTION
## What is the goal of this PR?

Grabl recently changed the `automation.yml` syntax to have `image` instead of `machine`

## What are the changes implemented in this PR?

* Replace all `machine:` usages with `image:`
* Only depend on `build` versions of other repos
