### PR TITLE
Fix console exitting when trying to open transaction to a database that doesn't exist

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -35,5 +35,5 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        tag = "2.0.0-alpha-4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        commit = "0ae01423da842b47669929975d50de307567fc2e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )


### PR DESCRIPTION
## What is the goal of this PR?

We have fixed an issue that caused console to exit when trying to open transaction to a database that doesn't exist.

## What are the changes implemented in this PR?

- Bump client-java to the version which no longer throws the incorrect exception, causing console to exit improperly
- Fix https://github.com/graknlabs/console/issues/98