### PR TITLE
Add Grakn Cluster support

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -47,7 +47,7 @@ build:
         export ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-        bazel build --config=rbe //...
+        bazel build //...
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
     deploy-artifact-snapshot:

--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -72,7 +72,7 @@ public class GraknConsole {
 
     public void run() {
         printer.info(COPYRIGHT);
-        try (Grakn.Client client = new GraknClient(options.address())) {
+        try (Grakn.Client client = new GraknClient.Cluster(options.address())) {
             runRepl(client);
         } catch (GraknClientException e) {
             printer.error(e.getMessage());
@@ -264,7 +264,7 @@ public class GraknConsole {
     @CommandLine.Command(name = "grakn console", mixinStandardHelpOptions = true, version = {grakn.console.Version.VERSION})
     public static class CommandLineOptions {
         @CommandLine.Option(names = {"--server"},
-                defaultValue = GraknClient.DEFAULT_URI,
+                defaultValue = GraknClient.DEFAULT_ADDRESS,
                 description = "Server address to which the console will connect to")
         private String address;
 

--- a/common/Printer.java
+++ b/common/Printer.java
@@ -28,8 +28,8 @@ import grakn.client.concept.thing.Relation;
 import grakn.client.concept.thing.Thing;
 import grakn.client.concept.type.RoleType;
 import grakn.client.concept.type.Type;
-import graql.lang.pattern.variable.Reference;
 import graql.lang.common.GraqlToken;
+import graql.lang.pattern.variable.Reference;
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStyle;
 
@@ -60,7 +60,7 @@ public class Printer {
     }
 
     public void conceptMapGroup(ConceptMapGroup answer, Grakn.Transaction tx) {
-        for (ConceptMap conceptMap: answer.conceptMaps()) {
+        for (ConceptMap conceptMap : answer.conceptMaps()) {
             out.println(conceptDisplayString(answer.owner(), tx) + " => " + conceptMapDisplayString(conceptMap, tx));
         }
     }
@@ -76,7 +76,7 @@ public class Printer {
     private String conceptMapDisplayString(ConceptMap conceptMap, Grakn.Transaction tx) {
         StringBuilder sb = new StringBuilder();
         sb.append("{ ");
-        for (Map.Entry<String, Concept> entry: conceptMap.map().entrySet()) {
+        for (Map.Entry<String, Concept> entry : conceptMap.map().entrySet()) {
             Reference.Name variable = Reference.named(entry.getKey());
             Concept concept = entry.getValue();
             sb.append(variable.syntax());

--- a/conf/logback/logback.xml
+++ b/conf/logback/logback.xml
@@ -15,5 +15,5 @@
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
 <configuration debug="false">
-    <root level="OFF" />
+    <root level="OFF"/>
 </configuration>

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -34,6 +34,6 @@ def graknlabs_common():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/lolski/client-java",
-        commit = "47977700aeebb94a95c585b3564462444178ed2a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/graknlabs/client-java",
+        commit = "d41db8972e07b5574482b008137ad152f38e919f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -34,6 +34,6 @@ def graknlabs_common():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
-        commit = "0ae01423da842b47669929975d50de307567fc2e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/lolski/client-java",
+        commit = "47977700aeebb94a95c585b3564462444178ed2a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )


### PR DESCRIPTION
## What is the goal of this PR?

We have added Grakn Cluster support. A user can connect to a cluster of Grakn Cluster instances using the `--cluster` flag:

```
./grakn console --cluster 172.0.01:1729
```

## What are the changes implemented in this PR?

- Adds a new flag `--cluster` for connecting to Grakn Cluster
- Update client-java to the version which supports cluster