### PR TITLE
Fix Grakn Console distribution for Windows

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -114,7 +114,7 @@ assemble_zip(
 assemble_zip(
     name = "assemble-windows-zip",
     output_filename = "grakn-console-windows",
-    targets = [":console-artifact", "@graknlabs_common//binary:assemble-bash-targz"],
+    targets = [":console-artifact", "@graknlabs_common//binary:assemble-bat-targz"],
     visibility = ["//visibility:public"]
 )
 


### PR DESCRIPTION
## What is the goal of this PR?

Make Grakn Console distributions for Windows operational by adding previously lacking `grakn.bat` (a Windows-specific script to start the Console).

## What are the changes implemented in this PR?

Correctly include Bat script if Console is being assembled for Windows