### PR TITLE
When no databases are present, say as much on database list

### DIFF
--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -114,7 +114,8 @@ public class GraknConsole {
                 reader.getTerminal().puts(InfoCmp.Capability.clear_screen);
             } else if (command.isDatabaseList()) {
                 try {
-                    client.databases().all().forEach(database -> printer.info(database));
+                    if (client.databases().all().size() > 0) client.databases().all().forEach(printer::info);
+                    else printer.info("No databases are present on the server.");
                 } catch (GraknClientException e) {
                     printer.error(e.getMessage());
                 }


### PR DESCRIPTION
## What is the goal of this PR?

Previously, running `database list` with no databases present on the server gave no output and was difficult to distinguish from the console hanging or the server otherwise failing to respond. We added a more explicit response when no database is present on the server to make it clearer when this case has occurred.

## What are the changes implemented in this PR?

- `database list` with no databases present now prints `No databases are present on the server.` instead of nothing at all.
