### PR TITLE
Fix console not able to shutdown on exit and not close errored transaction

### DIFF
--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -108,11 +108,11 @@ public class GraknConsole {
             try {
                 command = ReplCommand.getCommand(reader, printer, "> ");
             } catch (InterruptedException e) {
-                shutdownQueryJobs();
+                executorService.shutdownNow();
                 break;
             }
             if (command.isExit()) {
-                shutdownQueryJobs();
+                executorService.shutdownNow();
                 break;
             } else if (command.isHelp()) {
                 printer.info(ReplCommand.getHelpMenu());
@@ -165,7 +165,7 @@ public class GraknConsole {
                     break;
                 }
                 if (command.isExit()) {
-                    shutdownQueryJobs();
+                    executorService.shutdownNow();
                     return true;
                 } else if (command.isClear()) {
                     reader.getTerminal().puts(InfoCmp.Capability.clear_screen);
@@ -265,17 +265,6 @@ public class GraknConsole {
             printer.info("The query has been cancelled. It may take some time for the cancellation to finish on the server side.");
         } finally {
             terminal.handle(Terminal.Signal.INT, Terminal.SignalHandler.SIG_IGN);
-        }
-    }
-
-    private void shutdownQueryJobs() {
-        executorService.shutdown();
-        try {
-            if (!executorService.awaitTermination(100, TimeUnit.MILLISECONDS)) {
-                executorService.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            executorService.shutdownNow();
         }
     }
 

--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -107,7 +107,7 @@ public class GraknConsole {
             ReplCommand command;
             try {
                 command = ReplCommand.getCommand(reader, printer, "> ");
-            } catch (InterruptedException e1) {
+            } catch (InterruptedException e) {
                 shutdownQueryJobs();
                 break;
             }
@@ -274,7 +274,7 @@ public class GraknConsole {
             if (!executorService.awaitTermination(100, TimeUnit.MILLISECONDS)) {
                 executorService.shutdownNow();
             }
-        } catch (InterruptedException e2) {
+        } catch (InterruptedException e) {
             executorService.shutdownNow();
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

Fix two issues in the console. First, we properly shutdown the console when users type `exit` command in both levels of the REPL. Second, when a transaction is errored, we properly return from the transaction REPL as the transaction has been closed and not usable anymore.

## What are the changes implemented in this PR?

- Call `executorService.shutdown();` on `exit` command. Fix https://github.com/graknlabs/console/issues/118
- Throw exceptions from query jobs to the main thread so that the transaction is properly closed. Fix https://github.com/graknlabs/console/issues/119