### PR TITLE
Always deploy artifacts bundled together with a shell startup script

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -63,7 +63,9 @@ build:
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         export DEPLOY_ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //:deploy-console-artifact -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-targz -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-zip -- snapshot
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-zip -- snapshot
     deploy-apt-snapshot:
       filter:
         owner: graknlabs
@@ -154,5 +156,7 @@ release:
         bazel run @graknlabs_dependencies//distribution/artifact:create-netrc
         export DEPLOY_ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_ARTIFACT_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run --define version=$(cat VERSION) //:deploy-console-artifact -- release
-    
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-linux-targz -- release
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-zip -- release
+        bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-zip -- release
+

--- a/BUILD
+++ b/BUILD
@@ -80,21 +80,11 @@ java_deps(
 pkg_tar(
     name = "console-artifact",
     deps = [":console-deps"],
-    extension = "tgz",
+    extension = "tar.gz",
     files = {
         "//conf/logback:logback.xml": "console/conf/logback.xml"
     },
     visibility = ["//visibility:public"]
-)
-
-deploy_artifact(
-    name = "deploy-console-artifact",
-    target = ":console-artifact",
-    artifact_group = "graknlabs_console",
-    artifact_name = "console-artifact.tgz",
-    snapshot = deployment['artifact.snapshot'],
-    release = deployment['artifact.release'],
-    visibility = ["//visibility:public"],
 )
 
 assemble_targz(
@@ -116,6 +106,36 @@ assemble_zip(
     output_filename = "grakn-console-windows",
     targets = [":console-artifact", "@graknlabs_common//binary:assemble-bat-targz"],
     visibility = ["//visibility:public"]
+)
+
+deploy_artifact(
+    name = "deploy-linux-targz",
+    target = ":assemble-linux-targz",
+    artifact_group = "graknlabs_console",
+    artifact_name = "grakn-core-console-linux-{version}.tar.gz",
+    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact.release'],
+    visibility = ["//visibility:public"],
+)
+
+deploy_artifact(
+    name = "deploy-mac-zip",
+    target = ":assemble-mac-zip",
+    artifact_group = "graknlabs_console",
+    artifact_name = "grakn-core-console-mac-{version}.tar.gz",
+    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact.release'],
+    visibility = ["//visibility:public"],
+)
+
+deploy_artifact(
+    name = "deploy-windows-zip",
+    target = ":assemble-windows-zip",
+    artifact_group = "graknlabs_console",
+    artifact_name = "grakn-core-console-windows-{version}.tar.gz",
+    snapshot = deployment['artifact.snapshot'],
+    release = deployment['artifact.release'],
+    visibility = ["//visibility:public"],
 )
 
 assemble_versioned(


### PR DESCRIPTION
## What is the goal of this PR?

Always deploy artifacts bundled together with a shell startup script. 

## What are the changes implemented in this PR?

- Deploy shell script together with artifact.
- Rename `tgz` to `tar.gz` to be more consistent with server.