### PR TITLE
Add 'database replicas' command

### DIFF
--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -83,7 +83,7 @@ public class GraknConsole {
         if (options.server() != null) {
             client = GraknClient.core(options.server());
         } else if (options.cluster() != null) {
-            client = GraknClient.cluster(options.cluster());
+            client = GraknClient.cluster(options.cluster().split(","));
         } else {
             client = GraknClient.core();
         }
@@ -254,13 +254,26 @@ public class GraknConsole {
 
     private boolean runDatabaseList(GraknClient client) {
         try {
-            if (client.databases().all().size() > 0) client.databases().all().forEach(database -> printer.info(database));
+            if (client.databases().all().size() > 0) client.databases().all().forEach(this::printDatabase);
             else printer.info("No databases are present on the server.");
             return true;
         } catch (GraknClientException e) {
             printer.error(e.getMessage());
             return false;
         }
+    }
+
+    private void printDatabase(GraknClient.Database database) {
+        String s;
+        if (database instanceof GraknClient.Database.Cluster) {
+            GraknClient.Database.Cluster clusterDatabase = (GraknClient.Database.Cluster) database;
+            s = clusterDatabase.name() + ": " + clusterDatabase.replicas().stream()
+                    .map(r -> String.format("(%s, %s, term=%d)", r.address(), r.isPrimary() ? "primary" : "secondary", r.term()))
+                    .collect(Collectors.joining(", "));
+        } else {
+            s = database.name();
+        }
+        printer.info(s);
     }
 
     private boolean runDatabaseCreate(GraknClient client, String database) {
@@ -276,7 +289,7 @@ public class GraknConsole {
 
     private boolean runDatabaseDelete(GraknClient client, String database) {
         try {
-            client.databases().delete(database);
+            client.databases().get(database).delete();
             printer.info("Database '" + database + "' deleted");
             return true;
         } catch (GraknClientException e) {

--- a/command/ReplCommand.java
+++ b/command/ReplCommand.java
@@ -34,7 +34,7 @@ public interface ReplCommand {
     }
 
     default Exit asExit() {
-        throw new grakn.console.GraknConsoleException(ILLEGAL_CAST);
+        throw new GraknConsoleException(ILLEGAL_CAST);
     }
 
     default boolean isHelp() {
@@ -42,7 +42,7 @@ public interface ReplCommand {
     }
 
     default Help asHelp() {
-        throw new grakn.console.GraknConsoleException(ILLEGAL_CAST);
+        throw new GraknConsoleException(ILLEGAL_CAST);
     }
 
     default boolean isClear() {
@@ -50,7 +50,7 @@ public interface ReplCommand {
     }
 
     default Clear asClear() {
-        throw new grakn.console.GraknConsoleException(ILLEGAL_CAST);
+        throw new GraknConsoleException(ILLEGAL_CAST);
     }
 
     default boolean isDatabaseList() {
@@ -58,7 +58,7 @@ public interface ReplCommand {
     }
 
     default Database.List asDatabaseList() {
-        throw new grakn.console.GraknConsoleException(ILLEGAL_CAST);
+        throw new GraknConsoleException(ILLEGAL_CAST);
     }
 
     default boolean isDatabaseCreate() {
@@ -66,7 +66,7 @@ public interface ReplCommand {
     }
 
     default Database.Create asDatabaseCreate() {
-        throw new grakn.console.GraknConsoleException(ILLEGAL_CAST);
+        throw new GraknConsoleException(ILLEGAL_CAST);
     }
 
     default boolean isDatabaseDelete() {
@@ -74,7 +74,15 @@ public interface ReplCommand {
     }
 
     default Database.Delete asDatabaseDelete() {
-        throw new grakn.console.GraknConsoleException(ILLEGAL_CAST);
+        throw new GraknConsoleException(ILLEGAL_CAST);
+    }
+
+    default boolean isDatabaseReplicas() {
+        return false;
+    }
+
+    default Database.Replicas asDatabaseReplicas() {
+        throw new GraknConsoleException(ILLEGAL_CAST);
     }
 
     default boolean isTransaction() {
@@ -82,7 +90,7 @@ public interface ReplCommand {
     }
 
     default Transaction asTransaction() {
-        throw new grakn.console.GraknConsoleException(ILLEGAL_CAST);
+        throw new GraknConsoleException(ILLEGAL_CAST);
     }
 
     class Exit implements ReplCommand {
@@ -210,6 +218,33 @@ public interface ReplCommand {
                 return this;
             }
         }
+
+        public static class Replicas extends ReplCommand.Database {
+
+            private static String token = "replicas";
+            private static String helpCommand = Database.token + " " + token + " " + "<db>";
+            private static String description = "List replicas of a database with name <db>";
+
+            private final String database;
+
+            public Replicas(String database) {
+                this.database = database;
+            }
+
+            public String database() {
+                return database;
+            }
+
+            @Override
+            public boolean isDatabaseReplicas() {
+                return true;
+            }
+
+            @Override
+            public Database.Replicas asDatabaseReplicas() {
+                return this;
+            }
+        }
     }
 
     class Transaction implements ReplCommand {
@@ -256,6 +291,7 @@ public interface ReplCommand {
                 pair(Database.List.helpCommand, Database.List.description),
                 pair(Database.Create.helpCommand, Database.Create.description),
                 pair(Database.Delete.helpCommand, Database.Delete.description),
+                pair(Database.Replicas.helpCommand, Database.Replicas.description),
                 pair(Transaction.helpCommand, Transaction.description),
                 pair(Help.helpCommand, Help.description),
                 pair(Clear.helpCommand, Clear.description),
@@ -294,6 +330,9 @@ public interface ReplCommand {
         } else if (tokens.length == 3 && tokens[0].equals(Database.token) && tokens[1].equals(Database.Delete.token)) {
             String database = tokens[2];
             command = new Database.Delete(database);
+        } else if (tokens.length == 3 && tokens[0].equals(Database.token) && tokens[1].equals(Database.Replicas.token)) {
+            String database = tokens[2];
+            command = new Database.Replicas(database);
         } else if (tokens.length == 4 && tokens[0].equals(Transaction.token) &&
                 (tokens[2].equals("schema") || tokens[2].equals("data") && (tokens[3].equals("read") || tokens[3].equals("write")))) {
             String database = tokens[1];

--- a/common/Printer.java
+++ b/common/Printer.java
@@ -73,6 +73,15 @@ public class Printer {
         out.println(conceptDisplayString(answer.owner(), tx) + " => " + answer.numeric().asNumber());
     }
 
+    public void databaseReplica(GraknClient.Database.Replica replica) {
+        String s = "{ " +
+                colorJsonKey("address: ") + replica.address().client() + ";" +
+                colorJsonKey(" role: ") + (replica.isPrimary() ? "primary" : "secondary") + ";" +
+                colorJsonKey(" term: ") + replica.term() +
+                " }";
+        out.println(s);
+    }
+
     private String conceptMapDisplayString(ConceptMap conceptMap, GraknClient.Transaction tx) {
         StringBuilder sb = new StringBuilder();
         sb.append("{ ");
@@ -170,5 +179,9 @@ public class Printer {
 
     private String colorError(String s) {
         return new AttributedString(s, AttributedStyle.DEFAULT.foreground(AttributedStyle.RED)).toAnsi();
+    }
+
+    private String colorJsonKey(String s) {
+        return new AttributedString(s, AttributedStyle.DEFAULT.foreground(AttributedStyle.BLUE)).toAnsi();
     }
 }

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -34,6 +34,6 @@ def graknlabs_common():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
-        tag = "2.0.0-alpha-9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/alexjpwalker/client-java",
+        commit = "cf08308a66f2a809909d2de592f96d4e6230984a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -35,5 +35,5 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        commit = "4b682c1363d0bc4600184c7cf82f948090cfade7",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        commit = "6468f7cb1d5cb575241f20418bf7b493a70242ca",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -35,5 +35,5 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/alexjpwalker/client-java",
-        commit = "cf08308a66f2a809909d2de592f96d4e6230984a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        commit = "0f5c0645f640180000933d96c2dd9d6ca45411eb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -35,5 +35,5 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/alexjpwalker/client-java",
-        commit = "0f5c0645f640180000933d96c2dd9d6ca45411eb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        commit = "2eac92aa9003fcb27474fc40b1c633114992e49c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -34,6 +34,6 @@ def graknlabs_common():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/alexjpwalker/client-java",
-        commit = "2eac92aa9003fcb27474fc40b1c633114992e49c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/graknlabs/client-java",
+        commit = "4b682c1363d0bc4600184c7cf82f948090cfade7",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )


### PR DESCRIPTION
## What is the goal of this PR?

We added the 'database replicas' command for Grakn Cluster, which lists information about the replicas of a specified database. It includes: the network address of each replica, its role (primary/secondary), and the term of the most recent election it took part in.

## What are the changes implemented in this PR?

Add 'database replicas' command
