### PR TITLE
Add option to read from any replica in Cluster

### DIFF
--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -18,6 +18,7 @@
 package grakn.console;
 
 import grakn.client.GraknClient;
+import grakn.client.GraknOptions;
 import grakn.client.common.exception.GraknClientException;
 import grakn.client.concept.answer.ConceptMap;
 import grakn.client.concept.answer.ConceptMapGroup;
@@ -113,7 +114,7 @@ public class GraknConsole {
             for (; i < commandStrings.size() && !cancelled[0]; i++) {
                 String commandString = commandStrings.get(i);
                 printer.info("+ " + commandString);
-                ReplCommand command = ReplCommand.getCommand(commandString);
+                ReplCommand command = ReplCommand.getCommand(commandString, client);
                 if (command != null) {
                     if (command.isDatabaseList()) {
                         boolean success = runDatabaseList(client);
@@ -131,7 +132,12 @@ public class GraknConsole {
                         String database = command.asTransaction().database();
                         GraknClient.Session.Type sessionType = command.asTransaction().sessionType();
                         GraknClient.Transaction.Type transactionType = command.asTransaction().transactionType();
-                        try (GraknClient.Session session = client.session(database, sessionType);
+                        GraknOptions sessionOptions = command.asTransaction().options();
+                        if (sessionOptions.isCluster() && !client.isCluster()) {
+                            printer.error("The option '--any-replica' is only available in Grakn Cluster.");
+                            return false;
+                        }
+                        try (GraknClient.Session session = client.session(database, sessionType, sessionOptions);
                              GraknClient.Transaction tx = session.transaction(transactionType)) {
                             for (i += 1; i < commandStrings.size() && !cancelled[0]; i++) {
                                 String txCommandString = commandStrings.get(i);
@@ -197,14 +203,14 @@ public class GraknConsole {
         while (true) {
             ReplCommand command;
             try {
-                command = ReplCommand.getCommand(reader, printer, "> ");
+                command = ReplCommand.getCommand(reader, printer, "> ", client);
             } catch (InterruptedException e) {
                 break;
             }
             if (command.isExit()) {
                 break;
             } else if (command.isHelp()) {
-                printer.info(ReplCommand.getHelpMenu());
+                printer.info(ReplCommand.getHelpMenu(client));
             } else if (command.isClear()) {
                 reader.getTerminal().puts(InfoCmp.Capability.clear_screen);
             } else if (command.isDatabaseList()) {
@@ -219,24 +225,31 @@ public class GraknConsole {
                 String database = command.asTransaction().database();
                 GraknClient.Session.Type sessionType = command.asTransaction().sessionType();
                 GraknClient.Transaction.Type transactionType = command.asTransaction().transactionType();
-                boolean shouldExit = runTransactionRepl(client, database, sessionType, transactionType);
+                GraknOptions options = command.asTransaction().options();
+                if (options.isCluster() && !client.isCluster()) {
+                    printer.error("The option '--any-replica' is only available in Grakn Cluster.");
+                    continue;
+                }
+                boolean shouldExit = runTransactionRepl(client, database, sessionType, transactionType, options);
                 if (shouldExit) break;
             }
         }
     }
 
-    private boolean runTransactionRepl(GraknClient client, String database, GraknClient.Session.Type sessionType, GraknClient.Transaction.Type transactionType) {
+    private boolean runTransactionRepl(GraknClient client, String database, GraknClient.Session.Type sessionType, GraknClient.Transaction.Type transactionType, GraknOptions options) {
         LineReader reader = LineReaderBuilder.builder()
                 .terminal(terminal)
                 .variable(LineReader.HISTORY_FILE, Paths.get(System.getProperty("user.home"), ".grakn-console-transaction-history").toAbsolutePath())
                 .build();
-        String prompt = database + "::" + sessionType.name().toLowerCase() + "::" + transactionType.name().toLowerCase() + "> ";
-        try (GraknClient.Session session = client.session(database, sessionType);
+        StringBuilder prompt = new StringBuilder(database + "::" + sessionType.name().toLowerCase() + "::" + transactionType.name().toLowerCase());
+        if (options.isCluster() && options.asCluster().readAnyReplica().isPresent() && options.asCluster().readAnyReplica().get()) prompt.append("[any-replica]");
+        prompt.append("> ");
+        try (GraknClient.Session session = client.session(database, sessionType, options);
              GraknClient.Transaction tx = session.transaction(transactionType)) {
             while (true) {
                 TransactionReplCommand command;
                 try {
-                    command = TransactionReplCommand.getCommand(reader, prompt);
+                    command = TransactionReplCommand.getCommand(reader, prompt.toString());
                 } catch (InterruptedException e) {
                     break;
                 }

--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -112,7 +112,7 @@ public class GraknConsole {
             for (; i < commandStrings.size() && !cancelled[0]; i++) {
                 String commandString = commandStrings.get(i);
                 printer.info("+ " + commandString);
-                ReplCommand command = ReplCommand.getCommand(commandString, client);
+                ReplCommand command = ReplCommand.getCommand(commandString, client.isCluster());
                 if (command != null) {
                     if (command.isDatabaseList()) {
                         boolean success = runDatabaseList(client);
@@ -199,7 +199,7 @@ public class GraknConsole {
         while (true) {
             ReplCommand command;
             try {
-                command = ReplCommand.getCommand(reader, printer, "> ", client);
+                command = ReplCommand.getCommand(reader, printer, "> ", client.isCluster());
             } catch (InterruptedException e) {
                 break;
             }

--- a/command/ReplCommand.java
+++ b/command/ReplCommand.java
@@ -315,11 +315,11 @@ public interface ReplCommand {
         return Utils.buildHelpMenu(menu);
     }
 
-    static ReplCommand getCommand(LineReader reader, Printer printer, String prompt, GraknClient client) throws InterruptedException {
+    static ReplCommand getCommand(LineReader reader, Printer printer, String prompt, boolean isCluster) throws InterruptedException {
         ReplCommand command = null;
         while (command == null) {
             String line = Utils.readNonEmptyLine(reader, prompt);
-            command = getCommand(line, client);
+            command = getCommand(line, isCluster);
             if (command == null) {
                 printer.error("Unrecognised command, please check help menu");
             }
@@ -328,7 +328,7 @@ public interface ReplCommand {
         return command;
     }
 
-    static ReplCommand getCommand(String line, GraknClient client) {
+    static ReplCommand getCommand(String line, boolean isCluster) {
         ReplCommand command = null;
         String[] tokens = Utils.splitLineByWhitespace(line);
         if (tokens.length == 1 && tokens[0].equals(Exit.token)) {
@@ -355,7 +355,7 @@ public interface ReplCommand {
             GraknClient.Transaction.Type transactionType = tokens[3].equals("read") ? GraknClient.Transaction.Type.READ : GraknClient.Transaction.Type.WRITE;
             GraknOptions options;
             if (tokens.length > 4 && tokens[4].equals("--any-replica")) options = GraknOptions.cluster().readAnyReplica(true);
-            else options = client.isCluster() ? GraknOptions.cluster() : GraknOptions.core();
+            else options = isCluster ? GraknOptions.cluster() : GraknOptions.core();
             command = new Transaction(database, sessionType, transactionType, options);
         }
         return command;

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -34,6 +34,6 @@ def graknlabs_common():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/alexjpwalker/client-java",
-        commit = "133b809727248ddda5914c5802477771c227a55a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/graknlabs/client-java",
+        commit = "42b25b2a44abe13f0ad09318c1d5df4642737a3b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -34,6 +34,6 @@ def graknlabs_common():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
-        commit = "6468f7cb1d5cb575241f20418bf7b493a70242ca",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/alexjpwalker/client-java",
+        commit = "133b809727248ddda5914c5802477771c227a55a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )


### PR DESCRIPTION
## What is the goal of this PR?

We added the `--any-replica` flag when opening a transaction in Cluster. When `--any-replica` is set, the transaction may read from any database replica, including secondary replicas.

## What are the changes implemented in this PR?

- Add option to read from any replica in Cluster
- When connecting to Grakn Core, the `help` command now only shows commands (and flags) that can be used in Core