### PR TITLE
Introduce transaction options

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -67,6 +67,8 @@ java_binary(
     main_class = "grakn.console.GraknConsole",
     runtime_deps = [":console"],
     visibility = ["//:__pkg__"],
+    resource_strip_prefix = "conf/logback",
+    resources = ["//conf/logback:logback.xml"]
 )
 
 java_deps(

--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -245,7 +245,7 @@ public class GraknConsole {
         if (options.isCluster() && options.asCluster().readAnyReplica().isPresent() && options.asCluster().readAnyReplica().get()) prompt.append("[any-replica]");
         prompt.append("> ");
         try (GraknClient.Session session = client.session(database, sessionType, options);
-             GraknClient.Transaction tx = session.transaction(transactionType)) {
+             GraknClient.Transaction tx = session.transaction(transactionType, options)) {
             while (true) {
                 TransactionReplCommand command;
                 try {

--- a/command/ReplCommand.java
+++ b/command/ReplCommand.java
@@ -254,7 +254,7 @@ public interface ReplCommand {
     class Transaction implements ReplCommand {
 
         private static String token = "transaction";
-        private static String helpCommand = token + " <db> schema|data read|writes [" + Options.token + "]";
+        private static String helpCommand = token + " <db> schema|data read|write [" + Options.token + "]";
         private static String description = "Start a transaction to database <db> with schema or data session, with read or write transaction";
 
         private final String database;

--- a/command/ReplCommand.java
+++ b/command/ReplCommand.java
@@ -372,7 +372,6 @@ public interface ReplCommand {
                 }
                 return optionsMenu;
             }
-
         }
 
         static class Cluster extends Core {

--- a/command/ReplCommand.java
+++ b/command/ReplCommand.java
@@ -340,13 +340,13 @@ public interface ReplCommand {
 
             static List<Option.Core> options = list(
                     Option.core("infer", Option.Arg.BOOLEAN, "Enable or disable inference", (opt, arg) -> opt.infer((Boolean) arg)),
-                    Option.core("traceInference", Option.Arg.BOOLEAN, "Enable or disable inference tracing", (opt, arg) -> opt.traceInference((Boolean) arg)),
+                    Option.core("trace-inference", Option.Arg.BOOLEAN, "Enable or disable inference tracing", (opt, arg) -> opt.traceInference((Boolean) arg)),
                     Option.core("explain", Option.Arg.BOOLEAN, "Enable or disable inference explanations", (opt, arg) -> opt.explain((Boolean) arg)),
                     Option.core("parallel", Option.Arg.BOOLEAN, "Enable or disable parallel query execution", (opt, arg) -> opt.parallel((Boolean) arg)),
-                    Option.core("batchSize", Option.Arg.INTEGER, "Set RPC answer batch size", (opt, arg) -> opt.batchSize((Integer) arg)),
+                    Option.core("batch-size", Option.Arg.INTEGER, "Set RPC answer batch size", (opt, arg) -> opt.batchSize((Integer) arg)),
                     Option.core("prefetch", Option.Arg.BOOLEAN, "Enable or disable RPC answer prefetch ", (opt, arg) -> opt.prefetch((Boolean) arg)),
-                    Option.core("sessionIdleTimeout", Option.Arg.INTEGER, "Kill idle session timeout (ms)", (opt, arg) -> opt.sessionIdleTimeout((Integer) arg)),
-                    Option.core("schemaLockAcquireTimeout", Option.Arg.INTEGER, "Acquire exclusive schema session timeout (ms)", (opt, arg) -> opt.schemaLockAcquireTimeout((Integer) arg))
+                    Option.core("session-idle-timeout", Option.Arg.INTEGER, "Kill idle session timeout (ms)", (opt, arg) -> opt.sessionIdleTimeout((Integer) arg)),
+                    Option.core("schema-lock-acquire-timeout", Option.Arg.INTEGER, "Acquire exclusive schema session timeout (ms)", (opt, arg) -> opt.schemaLockAcquireTimeout((Integer) arg))
             );
 
             public static Option<GraknOptions> coreOption(String token) throws IllegalArgumentException {
@@ -377,7 +377,7 @@ public interface ReplCommand {
         static class Cluster extends Core {
 
             private static List<Option.Cluster> options = withCoreOptions(
-                    Option.cluster("readAnyReplica", Option.Arg.BOOLEAN, "Allow (possibly stale) reads from any replica", (opt, arg) -> opt.readAnyReplica((Boolean) arg))
+                    Option.cluster("read-any-replica", Option.Arg.BOOLEAN, "Allow (possibly stale) reads from any replica", (opt, arg) -> opt.readAnyReplica((Boolean) arg))
             );
 
             private static List<Option.Cluster> withCoreOptions(Option.Cluster... clusterOptions) {

--- a/common/exception/GraknConsoleException.java
+++ b/common/exception/GraknConsoleException.java
@@ -25,4 +25,12 @@ public class GraknConsoleException extends RuntimeException {
         super(error.toString());
         assert !getMessage().contains("%s");
     }
+
+    public GraknConsoleException(String errorMessage) {
+        super(errorMessage);
+    }
+
+    public GraknConsoleException(IllegalArgumentException e) {
+        super(e);
+    }
 }

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -25,6 +25,5 @@ def graknlabs_grakn_core_artifact():
         artifact_name = "grakn-core-server-linux-{version}.tar.gz",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "c04b5f105914c690cbd54e6bdc6a4eb9dda2b3e7",
-        #        commit = "b8a76edfdfec0ce087d5ea299410b8354d1db5e2",
+        commit = "b8a76edfdfec0ce087d5ea299410b8354d1db5e2",
     )

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -26,4 +26,5 @@ def graknlabs_grakn_core_artifact():
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
         commit = "c04b5f105914c690cbd54e6bdc6a4eb9dda2b3e7",
+        #        commit = "b8a76edfdfec0ce087d5ea299410b8354d1db5e2",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -35,5 +35,5 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/flyingsilverfin/client-java",
-        commit = "632a107231d4c0db043ec87766ef78ac8c6f0422",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        commit = "05bc213929fa88dd22e2e6a6e0e3571dd5df804b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -1,4 +1,4 @@
-#
+
 # Copyright (C) 2021 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
@@ -35,5 +35,5 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/flyingsilverfin/client-java",
-        commit = "05bc213929fa88dd22e2e6a6e0e3571dd5df804b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        commit = "632a107231d4c0db043ec87766ef78ac8c6f0422",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -34,6 +34,6 @@ def graknlabs_common():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
-        commit = "c3e2744b3f610228531ccde7a9d1271fc98df700",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/flyingsilverfin/client-java",
+        commit = "632a107231d4c0db043ec87766ef78ac8c6f0422",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -34,6 +34,6 @@ def graknlabs_common():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/flyingsilverfin/client-java",
-        commit = "632a107231d4c0db043ec87766ef78ac8c6f0422",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
+        remote = "https://github.com/graknlabs/client-java",
+        commit = "5d51459c78ab35965da028d6de2d0e3d140ccad8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_client_java
     )


### PR DESCRIPTION
## What is the goal of this PR?
Allow console users to set any transaction options they like, by introducing `Options` that can be provided as `--flag` when opening a transaction. This will simplify debugging (especially for reasoner), and allow us to experiment with parallel/not parallel, along with all other available options.

## What are the changes implemented in this PR?
* Create `Options` class with two inner classes - `Core` and `Cluster`
* Also create `Options.Options`, which handles parsing values from the command line
* Options also have help menus, etc, as expected.

