### PR TITLE
Actually save transaction option parameters to fields

### DIFF
--- a/command/ReplCommand.java
+++ b/command/ReplCommand.java
@@ -407,6 +407,7 @@ public interface ReplCommand {
                 this.name = name;
                 this.arg = arg;
                 this.description = description;
+                this.builder = builder;
             }
 
             static Option.Core core(String name, Arg arg, String description, BiFunction<GraknOptions, Object, GraknOptions> builder) {


### PR DESCRIPTION
## What is the goal of this PR?
Fix null pointer in transaction options that occurs because the option builder is not saved.

## What are the changes implemented in this PR?
* save builder to field