### PR TITLE
When closing a READ transaction, simply print "transaction closed"

### DIFF
--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -342,7 +342,8 @@ public class GraknConsole {
 
     private void runClose(GraknClient.Transaction tx) {
         tx.close();
-        printer.info("Transaction closed without committing changes");
+        if (tx.type().isWrite()) printer.info("Transaction closed without committing changes");
+        else printer.info("Transaction closed");
     }
 
     private boolean runSource(GraknClient.Transaction tx, String file) {


### PR DESCRIPTION
## What is the goal of this PR?

Previously when closing a READ transaction, it would print "Transaction closed without committing changes". "Without committing changes" was superfluous so we got rid of it.

## What are the changes implemented in this PR?

When closing a READ transaction, simply print "transaction closed"
