### PR TITLE
Tweak location of console libraries

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -76,7 +76,7 @@ java_binary(
 java_deps(
     name = "console-deps",
     target = ":console-binary",
-    java_deps_root = "console/services/lib/",
+    java_deps_root = "console/lib/",
     visibility = ["//visibility:public"],
 )
 
@@ -177,7 +177,7 @@ assemble_apt(
     archives = [":console-deps"],
     installation_dir = "/opt/grakn/core/",
     empty_dirs = [
-         "opt/grakn/core/console/services/lib/",
+         "opt/grakn/core/console/lib/",
     ],
 )
 

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -27,8 +27,8 @@ def graknlabs_dependencies():
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/graknlabs/common",
-        commit = "4725216686968b0725d8910403fe1cafd3072ea0" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        remote = "https://github.com/vmax/graknlabs-common",
+        commit = "d704cbaa9d5ff047f0a087df99bb982d84ce0c36" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_client_java():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -27,8 +27,8 @@ def graknlabs_dependencies():
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
-        remote = "https://github.com/vmax/graknlabs-common",
-        commit = "d704cbaa9d5ff047f0a087df99bb982d84ce0c36" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        remote = "https://github.com/graknlabs/common",
+        commit = "0104af615aedd7d1e5215dbc429c8977b5408358" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_client_java():


### PR DESCRIPTION
## What is the goal of this PR?

Improve consistency of Grakn Console distribution and help fix an issue with long filenames in the assembled archives for Grakn Cluster.

## What are the changes implemented in this PR?

Depends on graknlabs/common#100
Move console libraries into `console/lib/`
