### PR TITLE
Add 'database schema' to help command and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Grakn Console provides two levels of interaction: database-level commands and tr
   > database delete my-grakn-database
   Database 'my-grakn-database' deleted
   ```
+- `database schema <db>` : Print the schema of a database with name `<db>` on the server. For example:
+  ```
+  > database schema my-grakn-database
+  define
+  person sub entity;
+  ```
 - `transaction <db> schema|data read|write` : Start a transaction to database `<db>` with session type `schema` or `data`, and transaction type `write` or `read`. For example:
   ```
   > transaction my-grakn-database schema write

--- a/command/ReplCommand.java
+++ b/command/ReplCommand.java
@@ -512,7 +512,8 @@ public interface ReplCommand {
         List<Pair<String, String>> menu = new ArrayList<>(Arrays.asList(
                 pair(Database.List.helpCommand, Database.List.description),
                 pair(Database.Create.helpCommand, Database.Create.description),
-                pair(Database.Delete.helpCommand, Database.Delete.description)));
+                pair(Database.Delete.helpCommand, Database.Delete.description),
+                pair(Database.Schema.helpCommand, Database.Schema.description)));
 
 
         if (client.isCluster()) {


### PR DESCRIPTION
## What is the goal of this PR?

The `database schema` command, implemented in https://github.com/graknlabs/console/pull/143, was missing from the `help` command and the `README` file. We added it to both.

## What are the changes implemented in this PR?

Add 'database schema' to help command and README
