### PR TITLE
Transaction REPL checks arguments

### DIFF
--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -281,30 +281,38 @@ public class GraknConsole {
                 }
                 if (command.isSecond()) {
                     printer.error(command.second());
-                } else if (command.first().isExit()) {
-                    return true;
-                } else if (command.first().isClear()) {
-                    reader.getTerminal().puts(InfoCmp.Capability.clear_screen);
-                } else if (command.first().isHelp()) {
-                    printer.info(TransactionReplCommand.getHelpMenu());
-                } else if (command.first().isCommit()) {
-                    runCommit(tx);
-                    break;
-                } else if (command.first().isRollback()) {
-                    runRollback(tx);
-                } else if (command.first().isClose()) {
-                    runClose(tx);
-                    break;
-                } else if (command.first().isSource()) {
-                    runSource(tx, command.first().asSource().file());
-                } else if (command.first().isQuery()) {
-                    runQuery(tx, command.first().asQuery().query());
+                    continue;
+                } else {
+                    TransactionReplCommand replCommand = command.first();
+                    if (replCommand.isExit()) {
+                        return true;
+                    } else if (replCommand.isClear()) {
+                        reader.getTerminal().puts(InfoCmp.Capability.clear_screen);
+                    } else if (replCommand.isHelp()) {
+                        printer.info(TransactionReplCommand.getHelpMenu());
+                    } else if (replCommand.isCommit()) {
+                        runCommit(tx);
+                        break;
+                    } else if (replCommand.isRollback()) {
+                        runRollback(tx);
+                    } else if (replCommand.isClose()) {
+                        runClose(tx);
+                        break;
+                    } else if (replCommand.isSource()) {
+                        runSource(tx, replCommand.asSource().file());
+                    } else if (replCommand.isQuery()) {
+                        runQuery(tx, replCommand.asQuery().query());
+                    }
                 }
             }
         } catch (GraknClientException e) {
             printer.error(e.getMessage());
         }
         return false;
+    }
+
+    private executeTransactionReplCommand(TransactionReplCommand command) {
+
     }
 
     private boolean runDatabaseList(GraknClient client) {

--- a/GraknConsole.java
+++ b/GraknConsole.java
@@ -311,10 +311,6 @@ public class GraknConsole {
         return false;
     }
 
-    private executeTransactionReplCommand(TransactionReplCommand command) {
-
-    }
-
     private boolean runDatabaseList(GraknClient client) {
         try {
             if (client.databases().all().size() > 0)

--- a/command/TransactionReplCommand.java
+++ b/command/TransactionReplCommand.java
@@ -30,6 +30,13 @@ import java.util.List;
 
 import static grakn.common.collection.Collections.pair;
 import static grakn.console.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
+import static grakn.console.common.exception.ErrorMessage.TransactionRepl.INVALID_CLEAR_ARGS;
+import static grakn.console.common.exception.ErrorMessage.TransactionRepl.INVALID_CLOSE_ARGS;
+import static grakn.console.common.exception.ErrorMessage.TransactionRepl.INVALID_COMMIT_ARGS;
+import static grakn.console.common.exception.ErrorMessage.TransactionRepl.INVALID_EXIT_ARGS;
+import static grakn.console.common.exception.ErrorMessage.TransactionRepl.INVALID_HELP_ARGS;
+import static grakn.console.common.exception.ErrorMessage.TransactionRepl.INVALID_ROLLBACK_ARGS;
+import static grakn.console.common.exception.ErrorMessage.TransactionRepl.INVALID_SOURCE_ARGS;
 
 public interface TransactionReplCommand {
 
@@ -102,6 +109,7 @@ public interface TransactionReplCommand {
         private static String token = "exit";
         private static String helpCommand = token;
         private static String description = "Exit console";
+        private static int args = 0;
 
         @Override
         public boolean isExit() {
@@ -119,6 +127,7 @@ public interface TransactionReplCommand {
         private static String token = "help";
         private static String helpCommand = token;
         private static String description = "Print this help menu";
+        private static int args = 0;
 
         @Override
         public boolean isHelp() {
@@ -136,6 +145,7 @@ public interface TransactionReplCommand {
         private static String token = "clear";
         private static String helpCommand = token;
         private static String description = "Clear console screen";
+        private static int args = 0;
 
         @Override
         public boolean isClear() {
@@ -153,6 +163,7 @@ public interface TransactionReplCommand {
         private static String token = "commit";
         private static String helpCommand = token;
         private static String description = "Commit the transaction changes and close transaction";
+        private static int args = 0;
 
         @Override
         public boolean isCommit() {
@@ -170,6 +181,7 @@ public interface TransactionReplCommand {
         private static String token = "rollback";
         private static String helpCommand = token;
         private static String description = "Rollback the transaction to the beginning state";
+        private static int args = 0;
 
         @Override
         public boolean isRollback() {
@@ -187,6 +199,7 @@ public interface TransactionReplCommand {
         private static String token = "close";
         private static String helpCommand = token;
         private static String description = "Close the transaction without committing changes";
+        private static int args = 0;
 
         @Override
         public boolean isClose() {
@@ -204,6 +217,7 @@ public interface TransactionReplCommand {
         private static String token = "source";
         private static String helpCommand = token + " <file>";
         private static String description = "Run Graql queries in file";
+        private static int args = 1;
 
         private final String file;
 
@@ -281,19 +295,26 @@ public interface TransactionReplCommand {
     static TransactionReplCommand getCommand(String line) {
         TransactionReplCommand command;
         String[] tokens = Utils.splitLineByWhitespace(line);
-        if (tokens.length == 1 && tokens[0].equals(Exit.token)) {
+        if (tokens[0].equals(Exit.token)) {
+            if (tokens.length - 1 != Exit.args) throw new GraknConsoleException(INVALID_EXIT_ARGS.message(Exit.args, tokens.length - 1));
             command = new Exit();
-        } else if (tokens.length == 1 && tokens[0].equals(Help.token)) {
+        } else if (tokens[0].equals(Help.token)) {
+            if (tokens.length - 1 != Help.args) throw new GraknConsoleException(INVALID_HELP_ARGS.message(Help.args, tokens.length - 1));
             command = new Help();
-        } else if (tokens.length == 1 && tokens[0].equals(Clear.token)) {
+        } else if (tokens[0].equals(Clear.token)) {
+            if (tokens.length - 1 != Clear.args) throw new GraknConsoleException(INVALID_CLEAR_ARGS.message(Clear.args, tokens.length - 1));
             command = new Clear();
-        } else if (tokens.length == 1 && tokens[0].equals(Commit.token)) {
+        } else if (tokens[0].equals(Commit.token)) {
+            if (tokens.length - 1 != Commit.args) throw new GraknConsoleException(INVALID_COMMIT_ARGS.message(Commit.args, tokens.length - 1));
             command = new Commit();
-        } else if (tokens.length == 1 && tokens[0].equals(Rollback.token)) {
+        } else if (tokens[0].equals(Rollback.token)) {
+            if (tokens.length - 1 != Rollback.args) throw new GraknConsoleException(INVALID_ROLLBACK_ARGS.message(Rollback.args, tokens.length - 1));
             command = new Rollback();
-        } else if (tokens.length == 1 && tokens[0].equals(Close.token)) {
+        } else if (tokens[0].equals(Close.token)) {
+            if (tokens.length - 1 != Close.args) throw new GraknConsoleException(INVALID_CLOSE_ARGS.message(Close.args, tokens.length - 1));
             command = new Close();
-        } else if (tokens.length == 2 && tokens[0].equals(Source.token)) {
+        } else if (tokens[0].equals(Source.token)) {
+            if (tokens.length - 1 != Source.args) throw new GraknConsoleException(INVALID_SOURCE_ARGS.message(Source.args, tokens.length - 1));
             String file = tokens[1];
             command = new Source(file);
         } else {

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -23,6 +23,32 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
         super(codePrefix, codeNumber, messagePrefix, messageBody);
     }
 
+    public static class TransactionRepl extends ErrorMessage {
+
+        public static final TransactionRepl INVALID_EXIT_ARGS =
+                new TransactionRepl(1, "'exit' expects %s space-separated arguments, received %s.");
+        public static final TransactionRepl INVALID_HELP_ARGS =
+                new TransactionRepl(2, "'help' expects %s space-separated arguments, received %s.");
+        public static final TransactionRepl INVALID_CLEAR_ARGS =
+                new TransactionRepl(3, "'clear' expects %s space-separated arguments, received %s.");
+        public static final TransactionRepl INVALID_COMMIT_ARGS =
+                new TransactionRepl(4, "'commit' expects %s space-separated arguments, received %s.");
+        public static final TransactionRepl INVALID_ROLLBACK_ARGS =
+                new TransactionRepl(5, "'rollback' expects %s space-separated arguments, received %s.");
+        public static final TransactionRepl INVALID_CLOSE_ARGS =
+                new TransactionRepl(6, "'close' expects %s space-separated arguments, received %s.");
+        public static final TransactionRepl INVALID_SOURCE_ARGS =
+                new TransactionRepl(7, "'source' expects %s space-separated arguments, received %s.");
+
+        private static final String codePrefix = "TXN";
+        private static final String messagePrefix = "Invalid Transaction command";
+
+        TransactionRepl(int number, String message) {
+            super(codePrefix, number, messagePrefix, message);
+        }
+
+    }
+
     public static class Internal extends ErrorMessage {
         public static final Internal ILLEGAL_CAST =
                 new Internal(2, "Illegal casting operation from '%s' to '%s'.");
@@ -46,4 +72,5 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
             super(codePrefix, number, messagePrefix, message);
         }
     }
+
 }


### PR DESCRIPTION
## What is the goal of this PR?
To make the error in https://github.com/graknlabs/console/issues/139 much cleaner, we implement a check for the required number of space-separated arguments. An incorrect number of arguments is no longer a fatal error.

## What are the changes implemented in this PR?
* Transaction-level REPL check required number of argument, and fail gracefully otherwise
* mis-used transaction repl errors no longer kill the console